### PR TITLE
Fix line continuations in macro

### DIFF
--- a/snzip.h
+++ b/snzip.h
@@ -88,9 +88,9 @@
 #define SNZ_BSWAP32(x) _byteswap_ulong(x)  /* in intrin.h (msvc) */
 #else
 #define SNZ_BSWAP32(x) \
-    ((((x) >> 24) & 0x000000ffu) |
-     (((x) >> 8)  & 0x0000ff00u) |
-     (((x) << 8)  & 0x00ff0000u) |
+    ((((x) >> 24) & 0x000000ffu) | \
+     (((x) >> 8)  & 0x0000ff00u) | \
+     (((x) << 8)  & 0x00ff0000u) | \
      (((x) << 24) & 0xff000000u))
 #endif
 


### PR DESCRIPTION
Each line (except the last one) of multiline macro should end with backslash character, because some C compilers raise syntax errors, for example recent version of clang-llvm bundled with XCode:
```
$ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
gcc -DHAVE_CONFIG_H -I.     -g -O2 -Wall -I/usr/local/Cellar/snappy/1.1.3/include -MT snzip.o -MD -MP -MF .deps/snzip.Tpo -c -o snzip.o snzip.c
In file included from snzip.c:60:
./snzip.h:93:12: error: expected ')'
     (((x) << 8)  & 0x00ff0000u) |
           ^
./snzip.h:93:7: note: to match this '('
     (((x) << 8)  & 0x00ff0000u) |
      ^
...
```