### PR TITLE
Added -o path parameter

### DIFF
--- a/snzip.c
+++ b/snzip.c
@@ -393,10 +393,9 @@ int main(int argc, char **argv)
       size_t suffixlen = strlen(fmt->suffix);
       size_t reffilelen = infilelen;
       char *reffile = malloc(PATH_MAX);
-      sprintf(reffile, "%s", infile);
       if (output_path) {
-        /* if output path is specified, prepare reffile */
-        const char *lastpath = strrchr(reffile, '/');
+        /* if output_path is specified define reffile accordingly */
+        const char *lastpath = strrchr(infile, '/');
         if (lastpath != NULL) {
           sprintf(reffile, "%s/%s", output_path, lastpath + 1);
         }
@@ -404,6 +403,9 @@ int main(int argc, char **argv)
             sprintf(reffile, "%s", output_path);
         }
         reffilelen = strlen(reffile);
+      }
+      else {
+          sprintf(reffile, "%s", infile);
       }
       if (opt_uncompress) {
         /* check suffix */


### PR DESCRIPTION
Added `-o path` parameter to specify a custom destination/name for the output file.

- Applies `-k` and only applies if `-c` is not used.
- If the parameter points to a directory it uses the current naming method.
- If the parameter points to a new file uses it as a custom name.

### Compression examples
```sh

# Will output at ./custom_name.tar.sz
snzip -o custom_name.tar.sz archive.tar

# Will output at /some/path/archive.tar.sz
snzip -o /some/path archive.tar

# Will output at /some/path/custom_name.tsz
snzip -o /some/path/custom_name.tsz archive.tar

# Will output at /some/path/no_extension_file
snzip -o /some/path/no_extension_file archive.tar

```

### Uncompression examples
```sh

# Will output at ./custom_name.txt
snzip -d -o custom_name.txt archive.txt.sz

# Will output at /some/path/archive.txt
snzip -d -o /some/path archive.txt.sz

# Will output at /some/path/custom_name.txt
snzip -d -o /some/path/custom_name.txt archive.txt.sz

# Will output at /some/path/no_extension_file
snzip -d -o /some/path/no_extension_file archive.txt.sz

```